### PR TITLE
Fix variables decoder import

### DIFF
--- a/lib/queries/generateElm.js
+++ b/lib/queries/generateElm.js
@@ -105,6 +105,28 @@ var generateImports = function (intel) {
                 }
             });
         }
+        if (operation.variablesDecoder) {
+            visitDecoders(operation.variablesDecoder, {
+                value: function (decoder) {
+                    addImportOf(decoder.type);
+                    addImportOf(decoder.decoder);
+                },
+                constantString: function (decoder) {
+                    addImport("GraphQL.Helpers.Decode");
+                },
+                record: function (decoder) {
+                    decoder.fields.map(addWrapperImports);
+                    if (decoder.fields.length > 8) {
+                        addImport("GraphQL.Helpers.Decode");
+                    }
+                },
+                union: function (decoder) { },
+                unionOn: function (decoder) { },
+                empty: function (decoder) {
+                    addImportOf(decoder.decoder);
+                }
+            });
+        }
         visitDecoders(operation.data, {
             value: function (decoder) {
                 addImportOf(decoder.type);

--- a/src/gen/queries/generateElm.ts
+++ b/src/gen/queries/generateElm.ts
@@ -161,6 +161,29 @@ const generateImports = (intel: ElmIntel): string => {
       });
     }
 
+    if (operation.variablesDecoder) {
+      visitDecoders(operation.variablesDecoder, {
+        value: (decoder: ElmValueDecoder) => {
+          addImportOf(decoder.type);
+          addImportOf(decoder.decoder);
+        },
+        constantString: (decoder: ElmConstantStringDecoder) => {
+          addImport("GraphQL.Helpers.Decode");
+        },
+        record: (decoder: ElmRecordDecoder) => {
+          decoder.fields.map(addWrapperImports);
+          if (decoder.fields.length > 8) {
+            addImport("GraphQL.Helpers.Decode");
+          }
+        },
+        union: (decoder: ElmUnionDecoder) => {},
+        unionOn: (decoder: ElmUnionOnDecoder) => {},
+        empty: (decoder: ElmEmptyDecoder) => {
+          addImportOf(decoder.decoder);
+        }
+      });
+    }
+
     visitDecoders(operation.data, {
       value: (decoder: ElmValueDecoder) => {
         addImportOf(decoder.type);

--- a/tests/gen/fixtures/index.ts
+++ b/tests/gen/fixtures/index.ts
@@ -241,7 +241,8 @@ const getData = (): { [key: string]: FinalConfig } => ({
       "inputs-optional.gql",
       "inputs-mixed.gql",
       "inputs-multiple.gql",
-      "lists.gql"
+      "lists.gql",
+      "big.gql"
     ]
   })
 });

--- a/tests/gen/fixtures/variables/big.gql
+++ b/tests/gen/fixtures/variables/big.gql
@@ -1,0 +1,3 @@
+query Big($inputs: BigInput) {
+  big(inputs: $inputs)
+}

--- a/tests/gen/fixtures/variables/expected-output/Big.elm
+++ b/tests/gen/fixtures/variables/expected-output/Big.elm
@@ -1,0 +1,114 @@
+module Big exposing
+    ( BigInput
+    , BigQuery
+    , BigResponse
+    , BigVariables
+    , big
+    , bigInputDecoder
+    , bigVariablesDecoder
+    , encodeBigInput
+    , encodeBigVariables
+    )
+
+import GraphQL.Errors
+import GraphQL.Helpers.Decode
+import GraphQL.Operation
+import GraphQL.Optional
+import GraphQL.Response
+import Json.Decode
+import Json.Encode
+
+
+big : BigVariables -> GraphQL.Operation.Operation GraphQL.Operation.Query GraphQL.Errors.Errors BigQuery
+big variables =
+    GraphQL.Operation.withQuery
+        """query Big($inputs: BigInput) {
+big(inputs: $inputs)
+}"""
+        (Maybe.Just <| encodeBigVariables variables)
+        bigQueryDecoder
+        GraphQL.Errors.decoder
+
+
+type alias BigResponse =
+    GraphQL.Response.Response GraphQL.Errors.Errors BigQuery
+
+
+type alias BigVariables =
+    { inputs : GraphQL.Optional.Optional BigInput
+    }
+
+
+encodeBigVariables : BigVariables -> Json.Encode.Value
+encodeBigVariables inputs =
+    GraphQL.Optional.encodeObject
+        [ ( "inputs", GraphQL.Optional.map encodeBigInput inputs.inputs )
+        ]
+
+
+type alias BigInput =
+    { field1 : Int
+    , field2 : Int
+    , field3 : Int
+    , field4 : Int
+    , field5 : Int
+    , field6 : Int
+    , field7 : Int
+    , field8 : Int
+    , field9 : Int
+    , field10 : Int
+    , field11 : Int
+    , field12 : Int
+    }
+
+
+encodeBigInput : BigInput -> Json.Encode.Value
+encodeBigInput inputs =
+    Json.Encode.object
+        [ ( "field1", Json.Encode.int inputs.field1 )
+        , ( "field2", Json.Encode.int inputs.field2 )
+        , ( "field3", Json.Encode.int inputs.field3 )
+        , ( "field4", Json.Encode.int inputs.field4 )
+        , ( "field5", Json.Encode.int inputs.field5 )
+        , ( "field6", Json.Encode.int inputs.field6 )
+        , ( "field7", Json.Encode.int inputs.field7 )
+        , ( "field8", Json.Encode.int inputs.field8 )
+        , ( "field9", Json.Encode.int inputs.field9 )
+        , ( "field10", Json.Encode.int inputs.field10 )
+        , ( "field11", Json.Encode.int inputs.field11 )
+        , ( "field12", Json.Encode.int inputs.field12 )
+        ]
+
+
+bigVariablesDecoder : Json.Decode.Decoder BigVariables
+bigVariablesDecoder =
+    Json.Decode.map BigVariables
+        (GraphQL.Optional.fieldDecoder "inputs" bigInputDecoder)
+
+
+bigInputDecoder : Json.Decode.Decoder BigInput
+bigInputDecoder =
+    Json.Decode.map8 BigInput
+        (Json.Decode.field "field1" Json.Decode.int)
+        (Json.Decode.field "field2" Json.Decode.int)
+        (Json.Decode.field "field3" Json.Decode.int)
+        (Json.Decode.field "field4" Json.Decode.int)
+        (Json.Decode.field "field5" Json.Decode.int)
+        (Json.Decode.field "field6" Json.Decode.int)
+        (Json.Decode.field "field7" Json.Decode.int)
+        (Json.Decode.field "field8" Json.Decode.int)
+        |> GraphQL.Helpers.Decode.andMap (Json.Decode.field "field9" Json.Decode.int)
+        |> GraphQL.Helpers.Decode.andMap (Json.Decode.field "field10" Json.Decode.int)
+        |> GraphQL.Helpers.Decode.andMap (Json.Decode.field "field11" Json.Decode.int)
+        |> GraphQL.Helpers.Decode.andMap (Json.Decode.field "field12" Json.Decode.int)
+
+
+type alias BigQuery =
+    { big : Maybe.Maybe String
+    }
+
+
+bigQueryDecoder : Json.Decode.Decoder BigQuery
+bigQueryDecoder =
+    Json.Decode.map BigQuery
+        (Json.Decode.field "big" (Json.Decode.nullable Json.Decode.string))

--- a/tests/gen/fixtures/variables/schema.gql
+++ b/tests/gen/fixtures/variables/schema.gql
@@ -21,6 +21,8 @@ type Query {
 
   inputsMultiple(inputs: Inputs!, inputs2: Inputs): String
 
+  big(inputs: BigInput): String
+
   lists(
     ints: [Int!]
     floats: [Float]
@@ -49,4 +51,19 @@ input MixedInputs {
 
 input OtherInputs {
   string: String!
+}
+
+input BigInput {
+  field1: Int!
+  field2: Int!
+  field3: Int!
+  field4: Int!
+  field5: Int!
+  field6: Int!
+  field7: Int!
+  field8: Int!
+  field9: Int!
+  field10: Int!
+  field11: Int!
+  field12: Int!
 }


### PR DESCRIPTION
## Problem
Only `object` decoder is taken into account when deciding modules to import.

Steps to reproduce:
1. Have a query that uses big variable (has > 8 fields)
    ```graphql
    input BigInput {
      field1: Int!
      field2: Int!
      field3: Int!
      field4: Int!
      field5: Int!
      field6: Int!
      field7: Int!
      field8: Int!
      field9: Int!
      field10: Int!
      field11: Int!
      field12: Int!
    }
    ```

1. Generate elm file for that query
1. See that there's no import for `GraphQL.Helpers.Decode.andMap` and this error
```elm
I cannot find a `GraphQL.Helpers.Decode.andMap` variable:

120|         |> GraphQL.Helpers.Decode.andMap (GraphQL.Optional.fieldDecoder "field9" Json.Decode.int)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
I cannot find a `GraphQL.Helpers.Decode` import. These names seem close though:
```

## Solution
This PR takes into account `variablesDecoder` when deciding modules to Import.

Also added test. Run `npm run-script test-gen` to start the test.
